### PR TITLE
[GS-192] Android implementation

### DIFF
--- a/android/src/main/java/com/precisionnutrition/capacitordevicemodel/DeviceModel.java
+++ b/android/src/main/java/com/precisionnutrition/capacitordevicemodel/DeviceModel.java
@@ -25,6 +25,10 @@ public class DeviceModel extends Plugin {
         call.resolve(ret);
     }
 
+    // Android does not have an API for detecting simulators, so we look to
+    // Google for advice on that one.
+    //
+    // Source: https://github.com/flutter/plugins/blob/master/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/MethodCallHandlerImpl.java
     private boolean isSimulator() {
         return (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
             || Build.FINGERPRINT.startsWith("generic")

--- a/android/src/main/java/com/precisionnutrition/capacitordevicemodel/DeviceModel.java
+++ b/android/src/main/java/com/precisionnutrition/capacitordevicemodel/DeviceModel.java
@@ -5,16 +5,40 @@ import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
-
+import android.os.Build;
 @NativePlugin()
 public class DeviceModel extends Plugin {
 
     @PluginMethod()
-    public void echo(PluginCall call) {
-        String value = call.getString("value");
-
+    public void getInfo(PluginCall call) {
         JSObject ret = new JSObject();
-        ret.put("value", value);
-        call.success(ret);
+        Boolean isSimulator = isSimulator();
+
+        // Android handles notches different vs iOS, so this flag isn't needed
+        ret.put("hasNotch", false);
+        ret.put("isSimulator", isSimulator);
+        ret.put("modelName", Build.MODEL);
+        ret.put("platform", "android");
+
+        call.resolve(ret);
+    }
+
+    private boolean isSimulator() {
+        return (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+            || Build.FINGERPRINT.startsWith("generic")
+            || Build.FINGERPRINT.startsWith("unknown")
+            || Build.HARDWARE.contains("goldfish")
+            || Build.HARDWARE.contains("ranchu")
+            || Build.MODEL.contains("google_sdk")
+            || Build.MODEL.contains("Emulator")
+            || Build.MODEL.contains("Android SDK built for x86")
+            || Build.MANUFACTURER.contains("Genymotion")
+            || Build.PRODUCT.contains("sdk_google")
+            || Build.PRODUCT.contains("google_sdk")
+            || Build.PRODUCT.contains("sdk")
+            || Build.PRODUCT.contains("sdk_x86")
+            || Build.PRODUCT.contains("vbox86p")
+            || Build.PRODUCT.contains("emulator")
+            || Build.PRODUCT.contains("simulator");
     }
 }

--- a/android/src/main/java/com/precisionnutrition/capacitordevicemodel/DeviceModel.java
+++ b/android/src/main/java/com/precisionnutrition/capacitordevicemodel/DeviceModel.java
@@ -5,7 +5,9 @@ import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
+
 import android.os.Build;
+
 @NativePlugin()
 public class DeviceModel extends Plugin {
 

--- a/android/src/main/res/layout/bridge_layout_main.xml
+++ b/android/src/main/res/layout/bridge_layout_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -12,4 +12,4 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@precision-nutrition/capacitor-device-model",
-  "version": "0.15.0",
+  "version": "0.16.0-rc.0",
   "description": "Capture additional information about a native device.",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Adds a 1:1 compatible (with iOS, web) API for this plugin on the Android side.

Unfortunately there are too many Android devices to use an approach similar to iOS for `hasNotch`, and the one API that is available to us for detecting notches is not straightforward to implement here. (We want a boolean, Android's API returns a [DisplayCutout](https://developer.android.com/reference/android/view/DisplayCutout))

**TL;DR:** `hasNotch` always returns false for now due to the way we're using that property in Liberator. Notch support may be revised in the future, and we can revisit this at that time.

## Testing

I've found the best way to test local Capacitor plugins is to build the plugin, then in Liberator:

`npm i /path/to/plugin`

Then continue on the Liberator build pipeline.

https://precisionnutrition.atlassian.net/browse/GS-192